### PR TITLE
Fix tests: rename eval to kernel_eval (to avoid calling itself)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,14 @@ repos:
     - id: ruff-check
     # Run the formatter.
     - id: ruff-format
+
+- repo: local
+  hooks:
+  - id: pytest
+    name: pytest
+    entry: uv
+    args: [run, pytest]
+    language: python
+    types: [python]
+    pass_filenames: false
+    always_run: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ build-backend = "hatchling.build"
 dev = [
     "fastmcp>=2.2.0",
     "pytest>=8.4.2",
+    "pytest-asyncio>=1.2.0",
     "ruff>=0.14.3",
 ]
 commit = [

--- a/src/colab_mcp/runtime.py
+++ b/src/colab_mcp/runtime.py
@@ -4,9 +4,9 @@ from fastmcp import FastMCP
 mcp = FastMCP("runtime")
 
 
-# Add an eval tool
+# Add an execute code tool
 @mcp.tool()
-def eval(code: str):
+def execute_code(code: str):
     """(Eventually) Evaluates code in a Colab kernel."""
     # But for now, just evals here.
     return eval(code)

--- a/src/colab_mcp/runtime_test.py
+++ b/src/colab_mcp/runtime_test.py
@@ -1,5 +1,10 @@
 from colab_mcp import runtime
 
+import pytest
 
-def test_add():
-    assert runtime.eval("1+2") == 3
+
+@pytest.mark.asyncio
+async def test_execute_code():
+    result = await runtime.execute_code.run({"code": "1+2"})
+    assert len(result.content) == 1
+    assert result.content[0].text == "3"

--- a/uv.lock
+++ b/uv.lock
@@ -193,6 +193,7 @@ commit = [
 dev = [
     { name = "fastmcp" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -204,6 +205,7 @@ commit = [{ name = "pre-commit", specifier = ">=4.3.0" }]
 dev = [
     { name = "fastmcp", specifier = ">=2.2.0" },
     { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-asyncio", specifier = ">=1.2.0" },
     { name = "ruff", specifier = ">=0.14.3" },
 ]
 
@@ -881,6 +883,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095 },
 ]
 
 [[package]]


### PR DESCRIPTION
Add some async bits to accomodate fastmcp APIs, also configure pre-commit to run tests under uv. 