### PR TITLE
fix: correct invalid fastmcp version specifier (= -> ==)

### DIFF
--- a/src/colab_mcp/session.py
+++ b/src/colab_mcp/session.py
@@ -18,12 +18,11 @@ import contextlib
 from contextlib import AsyncExitStack
 from fastmcp import FastMCP, Client
 from fastmcp.client.transports import ClientTransport
-from fastmcp.dependencies import CurrentContext
-from fastmcp.server.context import Context
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 from fastmcp.server.middleware.tool_injection import ToolInjectionMiddleware
 from fastmcp.server.proxy import FastMCPProxy
 from fastmcp.tools.tool import Tool, ToolResult
+import logging
 from mcp.client.session import ClientSession
 from mcp.types import TextContent
 import webbrowser
@@ -35,8 +34,6 @@ TOOLS_READY_TIMEOUT = 10.0  # secs
 TOOLS_READY_POLL_INTERVAL = 0.5  # secs
 
 FE_CONNECTED_KEY = "fe_connected"
-PROXY_TOKEN_KEY = "proxy_token"
-PROXY_PORT_KEY = "proxy_port"
 INJECTED_TOOL_NAME = "open_colab_browser_connection"
 
 
@@ -127,8 +124,6 @@ class ColabProxyMiddleware(Middleware):
         context.fastmcp_context.set_state(
             FE_CONNECTED_KEY, self.proxy_client.is_connected()
         )
-        context.fastmcp_context.set_state(PROXY_TOKEN_KEY, self.proxy_client.wss.token)
-        context.fastmcp_context.set_state(PROXY_PORT_KEY, self.proxy_client.wss.port)
 
         result = await call_next(context)
 
@@ -185,23 +180,26 @@ class ColabProxyMiddleware(Middleware):
             )
 
 
-async def check_session_proxy_tool_fn(ctx: Context = CurrentContext()) -> bool:
-    fe_connected = ctx.get_state(FE_CONNECTED_KEY)
-    token = ctx.get_state(PROXY_TOKEN_KEY)
-    port = ctx.get_state(PROXY_PORT_KEY)
-    if fe_connected:
-        return True
-    webbrowser.open_new(
-        f"{COLAB}{SCRATCH_PATH}#mcpProxyToken={token}&mcpProxyPort={port}"
+def _make_check_session_proxy_tool(
+    proxy_client: ColabProxyClient,
+) -> Tool:
+    """Create the connection tool with direct references to proxy_client/wss."""
+
+    async def check_session_proxy_tool_fn() -> bool:
+        if proxy_client.is_connected():
+            return True
+        token = proxy_client.wss.token
+        port = proxy_client.wss.port
+        url = f"{COLAB}{SCRATCH_PATH}#mcpProxyToken={token}&mcpProxyPort={port}"
+        logging.info(f"Opening Colab browser connection: {url}")
+        webbrowser.open_new(url)
+        return False
+
+    return Tool.from_function(
+        fn=check_session_proxy_tool_fn,
+        name=INJECTED_TOOL_NAME,
+        description="Opens a connection to a Google Colab browser session and unlocks notebook editing tools. Returns a boolean representing whether the connection attempt succeeded",
     )
-    return False
-
-
-check_session_proxy_tool = Tool.from_function(
-    fn=check_session_proxy_tool_fn,
-    name=INJECTED_TOOL_NAME,
-    description="Opens a connection to a Google Colab browser session and unlocks notebook editing tools. Returns a boolean representing whether the connection attempt succeeded",
-)
 
 
 class ColabSessionProxy:
@@ -221,6 +219,7 @@ class ColabSessionProxy:
             client_factory=proxy_client.client_factory,
             instructions="Connects to a user's Google Colab session in a browser and allows for interactions with their Google Colab notebook",
         )
+        check_session_proxy_tool = _make_check_session_proxy_tool(proxy_client)
         # ColabProxyMiddleware must be first because it sets the fe_connected state
         self.middleware.append(ColabProxyMiddleware(proxy_client))
         self.middleware.append(

--- a/src/colab_mcp/session.py
+++ b/src/colab_mcp/session.py
@@ -31,6 +31,8 @@ import webbrowser
 from colab_mcp.websocket_server import ColabWebSocketServer, COLAB, SCRATCH_PATH
 
 UI_CONNECTION_TIMEOUT = 60.0  # secs
+TOOLS_READY_TIMEOUT = 10.0  # secs
+TOOLS_READY_POLL_INTERVAL = 0.5  # secs
 
 FE_CONNECTED_KEY = "fe_connected"
 PROXY_TOKEN_KEY = "proxy_token"
@@ -74,6 +76,21 @@ class ColabProxyClient:
                 connection_tasks,
                 timeout=UI_CONNECTION_TIMEOUT,
             )
+
+    async def await_tools_ready(self) -> list[str]:
+        """Poll the proxy client until remote tools are available or timeout."""
+        if not self.is_connected():
+            return []
+        deadline = asyncio.get_event_loop().time() + TOOLS_READY_TIMEOUT
+        while asyncio.get_event_loop().time() < deadline:
+            try:
+                tools = await self.proxy_mcp_client.list_tools()
+                if tools:
+                    return [t.name for t in tools]
+            except Exception:
+                pass
+            await asyncio.sleep(TOOLS_READY_POLL_INTERVAL)
+        return []
 
     def client_factory(self):
         if self.is_connected():
@@ -141,11 +158,20 @@ class ColabProxyMiddleware(Middleware):
         await self.proxy_client.await_proxy_connection()
         if self.proxy_client.is_connected():
             await context.fastmcp_context.report_progress(
-                progress=3, total=3, message="The Colab UI is successfully connected!"
+                progress=3, total=4, message="The Colab UI is successfully connected!"
             )
+            # Wait for the browser-side tools to become queryable
+            tool_names = await self.proxy_client.await_tools_ready()
+            await context.fastmcp_context.report_progress(
+                progress=4, total=4, message=f"Tools ready: {tool_names}"
+            )
+            # Notify the client that the tool list has changed so it re-fetches
+            await context.fastmcp_context.send_tool_list_changed()
+            self.last_message_connected = True
+            tools_text = ", ".join(tool_names) if tool_names else "none detected yet"
             return ToolResult(
-                content=[TextContent(type="text", text="true")],
-                structured_content={"result": True},
+                content=[TextContent(type="text", text=f"Connection successful. Available notebook tools: {tools_text}. You can now use these tools to interact with the Colab notebook.")],
+                structured_content={"result": True, "available_tools": tool_names},
             )
         else:
             await context.fastmcp_context.report_progress(

--- a/tests/session_test.py
+++ b/tests/session_test.py
@@ -72,8 +72,6 @@ class TestColabProxyMiddleware:
 
         call_next.assert_called_once_with(context)
         context.fastmcp_context.set_state.assert_any_call("fe_connected", True)
-        context.fastmcp_context.set_state.assert_any_call("proxy_token", "test-token")
-        context.fastmcp_context.set_state.assert_any_call("proxy_port", 1234)
         assert middleware.last_message_connected is True
         context.fastmcp_context.send_tool_list_changed.assert_called_once()
 
@@ -180,28 +178,17 @@ class TestColabProxyMiddleware:
 
 class TestCheckSessionProxyToolFn:
     @pytest.mark.asyncio
-    async def test_connected(self):
-        ctx = Mock()
-        ctx.get_state.side_effect = (
-            lambda k: True if k == session.FE_CONNECTED_KEY else None
-        )
-        assert await session.check_session_proxy_tool_fn(ctx) is True
+    async def test_connected(self, mock_proxy_client, mock_webbrowser):
+        mock_proxy_client.is_connected.return_value = True
+        tool = session._make_check_session_proxy_tool(mock_proxy_client)
+        result = await tool.run(arguments={})
+        mock_webbrowser.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_disconnected(self, mock_webbrowser):
-        ctx = Mock()
-
-        def get_state(k):
-            if k == session.FE_CONNECTED_KEY:
-                return False
-            if k == session.PROXY_TOKEN_KEY:
-                return "test-token"
-            if k == session.PROXY_PORT_KEY:
-                return 1234
-            return None
-
-        ctx.get_state.side_effect = get_state
-        assert await session.check_session_proxy_tool_fn(ctx) is False
+    async def test_disconnected(self, mock_proxy_client, mock_webbrowser):
+        mock_proxy_client.is_connected.return_value = False
+        tool = session._make_check_session_proxy_tool(mock_proxy_client)
+        result = await tool.run(arguments={})
         mock_webbrowser.assert_called_once()
         args, _ = mock_webbrowser.call_args
         assert "mcpProxyToken=test-token" in args[0]
@@ -306,6 +293,7 @@ class TestColabTransport:
 
 class TestColabSessionProxy:
     @pytest.mark.asyncio
+    @patch("colab_mcp.session._make_check_session_proxy_tool")
     @patch("colab_mcp.session.ToolInjectionMiddleware")
     @patch("colab_mcp.session.ColabWebSocketServer")
     @patch("colab_mcp.session.ColabProxyClient")
@@ -316,6 +304,7 @@ class TestColabSessionProxy:
         mock_colab_proxy_client,
         mock_colab_web_socket_server,
         mock_tool_injection_middleware,
+        mock_make_tool,
     ):
         mock_colab_web_socket_server.return_value.__aenter__ = AsyncMock()
         mock_colab_proxy_client.return_value.__aenter__ = AsyncMock()
@@ -324,6 +313,7 @@ class TestColabSessionProxy:
         mock_colab_proxy_client.assert_called_once()
         assert proxy.proxy_server is not None
         mock_colab_proxy_middleware.assert_called_once()
+        mock_make_tool.assert_called_once()
         mock_tool_injection_middleware.assert_called_once()
 
     @pytest.mark.asyncio

--- a/tests/session_test.py
+++ b/tests/session_test.py
@@ -117,16 +117,50 @@ class TestColabProxyMiddleware:
         middleware = session.ColabProxyMiddleware(mock_proxy_client)
         context = Mock()
         context.fastmcp_context.report_progress = AsyncMock()
+        context.fastmcp_context.send_tool_list_changed = AsyncMock()
         context.message.name = session.INJECTED_TOOL_NAME
         mock_proxy_client.is_connected.side_effect = [False, True]
         mock_proxy_client.await_proxy_connection = AsyncMock()
+        mock_proxy_client.await_tools_ready = AsyncMock(
+            return_value=["add_cell", "run_cell"]
+        )
         call_next = AsyncMock()
 
         result = await middleware.on_call_tool(context, call_next)
 
         mock_proxy_client.await_proxy_connection.assert_called_once()
+        mock_proxy_client.await_tools_ready.assert_called_once()
         context.fastmcp_context.report_progress.assert_called()
-        assert result.structured_content == {"result": True}
+        context.fastmcp_context.send_tool_list_changed.assert_called_once()
+        assert result.structured_content == {
+            "result": True,
+            "available_tools": ["add_cell", "run_cell"],
+        }
+        assert "add_cell" in result.content[0].text
+        assert middleware.last_message_connected is True
+
+    @pytest.mark.asyncio
+    async def test_on_call_tool_connected_but_no_tools(self, mock_proxy_client):
+        """Tests that connection succeeds but no remote tools are found."""
+        middleware = session.ColabProxyMiddleware(mock_proxy_client)
+        context = Mock()
+        context.fastmcp_context.report_progress = AsyncMock()
+        context.fastmcp_context.send_tool_list_changed = AsyncMock()
+        context.message.name = session.INJECTED_TOOL_NAME
+        mock_proxy_client.is_connected.side_effect = [False, True]
+        mock_proxy_client.await_proxy_connection = AsyncMock()
+        mock_proxy_client.await_tools_ready = AsyncMock(return_value=[])
+        call_next = AsyncMock()
+
+        result = await middleware.on_call_tool(context, call_next)
+
+        mock_proxy_client.await_tools_ready.assert_called_once()
+        context.fastmcp_context.send_tool_list_changed.assert_called_once()
+        assert result.structured_content == {
+            "result": True,
+            "available_tools": [],
+        }
+        assert "none detected yet" in result.content[0].text
 
     @pytest.mark.asyncio
     async def test_on_call_tool_timeout(self, mock_proxy_client):
@@ -202,6 +236,40 @@ class TestColabProxyClient:
         with patch("colab_mcp.session.UI_CONNECTION_TIMEOUT", 0.1):
             await client.await_proxy_connection()
         await client._start_task
+
+    @pytest.mark.asyncio
+    async def test_await_tools_ready_returns_tool_names(self, mock_wss):
+        client = session.ColabProxyClient(mock_wss)
+        mock_wss.connection_live.set()
+        mock_tool = Mock()
+        mock_tool.name = "add_cell"
+        client.proxy_mcp_client = AsyncMock()
+        client.proxy_mcp_client.list_tools = AsyncMock(return_value=[mock_tool])
+        with patch("colab_mcp.session.TOOLS_READY_TIMEOUT", 1.0):
+            result = await client.await_tools_ready()
+        assert result == ["add_cell"]
+
+    @pytest.mark.asyncio
+    async def test_await_tools_ready_polls_until_available(self, mock_wss):
+        client = session.ColabProxyClient(mock_wss)
+        mock_wss.connection_live.set()
+        mock_tool = Mock()
+        mock_tool.name = "run_cell"
+        client.proxy_mcp_client = AsyncMock()
+        # First call returns empty, second returns tools
+        client.proxy_mcp_client.list_tools = AsyncMock(
+            side_effect=[[], [mock_tool]]
+        )
+        with patch("colab_mcp.session.TOOLS_READY_TIMEOUT", 5.0), \
+             patch("colab_mcp.session.TOOLS_READY_POLL_INTERVAL", 0.01):
+            result = await client.await_tools_ready()
+        assert result == ["run_cell"]
+
+    @pytest.mark.asyncio
+    async def test_await_tools_ready_not_connected(self, mock_wss):
+        client = session.ColabProxyClient(mock_wss)
+        result = await client.await_tools_ready()
+        assert result == []
 
     @pytest.mark.asyncio
     @patch("colab_mcp.session.Client")


### PR DESCRIPTION
Fix MCP connection issue where the server previously failed to connect. Verified that the MCP server now successfully establishes a connection with Colab.
