### PR TITLE
feat: add headless/remote server support with fixed port option

### DIFF
--- a/src/colab_mcp/__init__.py
+++ b/src/colab_mcp/__init__.py
@@ -60,6 +60,12 @@ def parse_args(v):
         action="store_true",
         default=True,
     )
+    parser.add_argument(
+        "--port",
+        help="fixed port for the WebSocket server (default: random OS-assigned port).",
+        type=int,
+        default=0,
+    )
     return parser.parse_args(v)
 
 
@@ -69,7 +75,7 @@ async def main_async():
 
     if args.enable_proxy:
         logging.info("enabling session proxy tools")
-        session_mcp = ColabSessionProxy()
+        session_mcp = ColabSessionProxy(port=args.port)
         await session_mcp.start_proxy_server()
         mcp.mount(session_mcp.proxy_server)
         for middleware in session_mcp.middleware:

--- a/src/colab_mcp/session.py
+++ b/src/colab_mcp/session.py
@@ -129,14 +129,17 @@ class ColabProxyMiddleware(Middleware):
             return result
         if self.proxy_client.is_connected():
             return result
-        # if the tool call was for open_colab_browser_connection and there is no existing connection, try to await full connection
-        await context.fastmcp_context.report_progress(
-            progress=1, total=3, message="The user is not connected to the Colab UI"
+        token = self.proxy_client.wss.token
+        port = self.proxy_client.wss.port
+        fragment = f"mcpProxyToken={token}&mcpProxyPort={port}"
+        connection_info = (
+            f"Not yet connected. Append this fragment to any Colab notebook URL:\n"
+            f"  #{fragment}\n"
+            f"Or open: {COLAB}{SCRATCH_PATH}#{fragment}\n"
+            f"Waiting up to 60s for connection..."
         )
         await context.fastmcp_context.report_progress(
-            progress=2,
-            total=3,
-            message="Waiting for user to connect in Colab - will wait for 60s",
+            progress=1, total=3, message=connection_info
         )
         await self.proxy_client.await_proxy_connection()
         if self.proxy_client.is_connected():
@@ -144,7 +147,7 @@ class ColabProxyMiddleware(Middleware):
                 progress=3, total=3, message="The Colab UI is successfully connected!"
             )
             return ToolResult(
-                content=[TextContent(type="text", text="true")],
+                content=[TextContent(type="text", text=connection_info + "\n\nConnected successfully!")],
                 structured_content={"result": True},
             )
         else:
@@ -154,40 +157,46 @@ class ColabProxyMiddleware(Middleware):
                 message="Timeout while waiting for the user to connect.",
             )
             return ToolResult(
-                content=[TextContent(type="text", text="false")],
+                content=[TextContent(type="text", text=connection_info + "\n\nTimeout — connection not established.")],
                 structured_content={"result": False},
             )
 
 
-async def check_session_proxy_tool_fn(ctx: Context = CurrentContext()) -> bool:
+async def check_session_proxy_tool_fn(ctx: Context = CurrentContext()) -> str:
     fe_connected = ctx.get_state(FE_CONNECTED_KEY)
     token = ctx.get_state(PROXY_TOKEN_KEY)
     port = ctx.get_state(PROXY_PORT_KEY)
     if fe_connected:
-        return True
-    webbrowser.open_new(
-        f"{COLAB}{SCRATCH_PATH}#mcpProxyToken={token}&mcpProxyPort={port}"
+        return "Connected to Colab session."
+    connection_fragment = f"mcpProxyToken={token}&mcpProxyPort={port}"
+    url = f"{COLAB}{SCRATCH_PATH}#{connection_fragment}"
+    webbrowser.open_new(url)
+    return (
+        f"Not yet connected. The user must open a Colab notebook with the MCP connection fragment appended to the URL.\n\n"
+        f"Connection fragment: #{connection_fragment}\n\n"
+        f"Default URL: {url}\n\n"
+        f"To use an existing notebook, append #{connection_fragment} to its URL."
     )
-    return False
 
 
 check_session_proxy_tool = Tool.from_function(
     fn=check_session_proxy_tool_fn,
     name=INJECTED_TOOL_NAME,
-    description="Opens a connection to a Google Colab browser session and unlocks notebook editing tools. Returns a boolean representing whether the connection attempt succeeded",
+    description="Opens a connection to a Google Colab browser session and unlocks notebook editing tools. Returns connection info including the URL fragment to append to any Colab notebook URL.",
 )
 
 
 class ColabSessionProxy:
-    def __init__(self):
+    def __init__(self, port=0):
         self._exit_stack = AsyncExitStack()
         self.proxy_server: FastMCPProxy | None = None
         # list order matters, see: https://gofastmcp.com/servers/middleware#multiple-middleware
         self.middleware: list[Middleware] = []
         self.wss: ColabWebSocketServer | None = None
+        self._port = port
 
     async def start_proxy_server(self):
-        self.wss = await self._exit_stack.enter_async_context(ColabWebSocketServer())
+        self.wss = await self._exit_stack.enter_async_context(ColabWebSocketServer(port=self._port))
         proxy_client = await self._exit_stack.enter_async_context(
             ColabProxyClient(self.wss)
         )

--- a/src/colab_mcp/websocket_server.py
+++ b/src/colab_mcp/websocket_server.py
@@ -17,6 +17,7 @@ from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStre
 import asyncio
 import logging
 import mcp.types as types
+import pathlib
 from mcp.shared.message import SessionMessage
 from pydantic_core import ValidationError
 import secrets
@@ -39,9 +40,9 @@ class ColabWebSocketServer:
     from a Google Colab session (colab.google.com).
     """
 
-    def __init__(self, host="localhost"):
+    def __init__(self, host="localhost", port=0):
         self.host = host
-        self.port = 0
+        self.port = port
         self.connection_lock = asyncio.Lock()
         self.connection_live = asyncio.Event()
         self.allowed_origins = [COLAB, COLAB_ALT_DOMAIN]
@@ -144,13 +145,19 @@ class ColabWebSocketServer:
         self._server = await websockets.serve(
             self._connection_handler,
             host=self.host,
-            port=0,
+            port=self.port,
             subprotocols=[Subprotocol("mcp")],
             origins=self.allowed_origins,
             process_request=self._validate_authorization,
         )
         self.port = self._server.sockets[0].getsockname()[1]
         logging.info(f"Starting WebSocket server on ws://{self.host}:{self.port}")
+        fragment = f"mcpProxyToken={self.token}&mcpProxyPort={self.port}"
+        self.connection_info_path = pathlib.Path("/tmp/colab-mcp-connection.txt")
+        self.connection_info_path.write_text(
+            f"#{fragment}\n{COLAB}{SCRATCH_PATH}#{fragment}\n"
+        )
+        logging.info(f"Connection info written to {self.connection_info_path}")
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):


### PR DESCRIPTION
## Summary
- Adds `--port` CLI flag for a deterministic WebSocket port (defaults to `0`, preserving current random assignment)
- Returns the connection URL fragment in the tool response text, so MCP clients on remote/headless machines can surface it to the user
- Writes connection info to `/tmp/colab-mcp-connection.txt` for programmatic access
- Preserves `webbrowser.open_new()` for desktop users — fully backwards compatible

## Motivation
Running `colab-mcp` on a headless VM or SSH-connected server currently fails silently — `webbrowser.open_new()` can't open a browser, and the random WebSocket port makes SSH port forwarding unreliable across restarts. This is a common setup for users running Claude Code, Gemini CLI, or other MCP clients on cloud VMs.

With a fixed port (`--port 18585`), users can set up a persistent SSH tunnel and connect reliably:

```
ssh -L 18585:localhost:18585 user@remote-vm
```

The connection URL fragment is now always returned in the tool response, so agents can display it to the user regardless of whether a browser is available.

## Test plan
- [ ] Verify default behavior unchanged (no `--port` flag → random port, browser opens on desktop)
- [ ] Verify `--port 18585` binds to fixed port
- [ ] Verify tool response includes connection URL fragment
- [ ] Verify `/tmp/colab-mcp-connection.txt` is written on startup
- [ ] Verify SSH port forwarding + manual URL works on headless server

## Contributors
- [@galinilin](https://github.com/galinilin) (Gali Ün)
- Claude Opus 4.6 (Co-Author)